### PR TITLE
add 'with' setter prefix support

### DIFF
--- a/src/main/java/com/bruce/intellijplugin/generatesetter/actions/GenerateAllSetterBase.java
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/actions/GenerateAllSetterBase.java
@@ -44,6 +44,8 @@ import java.util.*;
 public abstract class GenerateAllSetterBase extends PsiElementBaseIntentionAction {
     public static final String IS = "is";
     public static final String GET = "get";
+    private static final String SET_SETTER_PREFIX = "set";
+    private static final String WITH_SETTER_PREFIX = "with";
     private final GenerateAllHandler generateAllHandler;
 
     public GenerateAllSetterBase(GenerateAllHandler generateAllHandler) {
@@ -245,8 +247,14 @@ public abstract class GenerateAllSetterBase extends PsiElementBaseIntentionActio
         StringBuilder builder = new StringBuilder();
         builder.append(splitText);
         for (PsiMethod method : methodList) {
-            if (method.getName().startsWith("set")) {
-                String fieldToLower = method.getName().substring(3)
+            String setterMethodNamePrefix =
+                    method.getName().startsWith(SET_SETTER_PREFIX)
+                            ? SET_SETTER_PREFIX
+                            : method.getName().startsWith(WITH_SETTER_PREFIX)
+                                    ? WITH_SETTER_PREFIX
+                                    : null;
+            if (setterMethodNamePrefix != null) {
+                String fieldToLower = method.getName().substring(setterMethodNamePrefix.length())
                         .toLowerCase();
                 PsiMethod s = info.getNameToMethodMap().get(fieldToLower);
                 if (s != null) {

--- a/src/main/java/com/bruce/intellijplugin/generatesetter/utils/PsiClassUtils.java
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/utils/PsiClassUtils.java
@@ -40,7 +40,9 @@ public class PsiClassUtils {
     }
 
     public static boolean isValidSetMethod(PsiMethod m) {
-        return m.hasModifierProperty("public") && !m.hasModifierProperty("static") && m.getName().startsWith("set");
+        return m.hasModifierProperty("public") &&
+                !m.hasModifierProperty("static") &&
+                (m.getName().startsWith("set") || m.getName().startsWith("with"));
     }
 
     public static boolean isValidGetMethod(PsiMethod m) {


### PR DESCRIPTION
Hi, friend. In my company we are using immutable objects, so we creates pojos using builders. It looks like this:
```
User user = User.builder()
    .withName("name")
    .withPassword("password")
    .build();
```

It would be great to be able generate setters for these builders to. It could be the first step for builders support.
