### PR TITLE
fix for default value with array for generate all setters with default value

### DIFF
--- a/src/main/java/com/bruce/intellijplugin/generatesetter/actions/GenerateAllSetterBase.java
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/actions/GenerateAllSetterBase.java
@@ -74,6 +74,13 @@ public abstract class GenerateAllSetterBase extends PsiElementBaseIntentionActio
         this.generateAllHandler = generateAllHandler;
     }
 
+    private static final Set<String> javaSimpleTypes = new HashSet<>(Arrays.asList(
+            "char",
+            "boolean",
+            "byte", "short", "int", "long",
+            "float", "double"
+    ));
+
     private static Map<String, String> typeGeneratedMap = new HashMap<String, String>() {
         {
             put("boolean", "false");
@@ -531,11 +538,17 @@ public abstract class GenerateAllSetterBase extends PsiElementBaseIntentionActio
                             Arrays.stream(allFields).findFirst().ifPresent(field -> builder.append(psiClassOfParameter.getName()).append(".").append(field.getName()));
                         }
                         else {
-                            builder.append("new "
-                                    + paramInfo.getParams().get(0).getRealName()
-                                    + "()");
+                            String realName = paramInfo.getParams().get(0).getRealName();
+
+                            if (realName.endsWith("[]")) {
+                                builder.append("new " + realName.replace("[]", "[0]"));
+                            } else {
+                                builder.append("new " + realName + "()");
+                            }
                         }
-                        newImportList.add(realPackage);
+                        if (!javaSimpleTypes.contains(realPackage.replace("[]", ""))) {
+                            newImportList.add(realPackage);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Hi,

Thanks for the great plugin.

This request is to fix problem with incorrect array values generation for default values.

<img width="442" alt="Screenshot 2023-07-22 at 22 31 31" src="https://github.com/gejun123456/intellij-generateAllSetMethod/assets/644816/3d55d221-b855-4d49-ba87-442acd605203">
