### PR TITLE
option to disable guava code generation. + splitter in preferences dialog.

### DIFF
--- a/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateAllSetterSettingForm.form
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateAllSetterSettingForm.form
@@ -15,103 +15,157 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="a574c" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="a574c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints border-constraint="North"/>
             <properties/>
             <border type="none"/>
             <children>
-              <component id="62a45" class="javax.swing.JCheckBox" binding="enableGenerateByTemplateCheckBox" default-binding="true">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="enable generate by template"/>
-                </properties>
-              </component>
-              <hspacer id="29fc7">
-                <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </hspacer>
-              <grid id="2fa98" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="fb8f2" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>
                 <children>
-                  <component id="be5e2" class="com.intellij.refactoring.ui.ClassNameReferenceEditor" binding="classNameReferenceEditor1" custom-create="true" default-binding="true">
+                  <component id="47e63" class="javax.swing.JCheckBox" binding="useOnlyJDKClassesCheckBox" default-binding="true">
                     <constraints>
-                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
-                    <properties/>
+                    <properties>
+                      <text value="Use only JDK classes (disables Guava)"/>
+                    </properties>
                   </component>
-                  <grid id="59676" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <hspacer id="3ddff">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                  </hspacer>
+                </children>
+              </grid>
+              <grid id="99e56" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="1" column="0" row-span="2" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <grid id="2fa98" binding="generateByTemplateSettings" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                     <border type="none"/>
                     <children>
-                      <component id="b97a8" class="javax.swing.JButton" binding="debugButton" default-binding="true">
+                      <component id="be5e2" class="com.intellij.refactoring.ui.ClassNameReferenceEditor" binding="classNameReferenceEditor1" custom-create="true" default-binding="true">
                         <constraints>
-                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                      </component>
+                      <grid id="59676" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                        <margin top="0" left="0" bottom="0" right="0"/>
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children>
+                          <component id="b97a8" class="javax.swing.JButton" binding="debugButton" default-binding="true">
+                            <constraints>
+                              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties>
+                              <text value="Debug"/>
+                            </properties>
+                          </component>
+                          <hspacer id="3732c">
+                            <constraints>
+                              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                          </hspacer>
+                          <component id="2ca29" class="com.intellij.ui.components.labels.LinkLabel" binding="exampleField">
+                            <constraints>
+                              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties>
+                              <text value="Read documentation"/>
+                            </properties>
+                          </component>
+                        </children>
+                      </grid>
+                    </children>
+                  </grid>
+                  <grid id="c6236" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none"/>
+                    <children>
+                      <component id="62a45" class="javax.swing.JCheckBox" binding="enableGenerateByTemplateCheckBox" default-binding="true">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <text value="debug"/>
+                          <text value="Enable generate by template"/>
                         </properties>
                       </component>
-                      <hspacer id="3732c">
+                      <hspacer id="2c3fa">
                         <constraints>
-                          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                       </hspacer>
-                      <component id="2ca29" class="com.intellij.ui.components.labels.LinkLabel" binding="exampleField">
-                        <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-                        </constraints>
-                        <properties>
-                          <text value="example"/>
-                        </properties>
-                      </component>
                     </children>
                   </grid>
                 </children>
               </grid>
             </children>
           </grid>
-          <grid id="3e5b" layout-manager="BorderLayout" hgap="0" vgap="0">
-            <constraints border-constraint="West"/>
-            <properties/>
-            <border type="none"/>
-            <children>
-              <component id="c0121" class="com.intellij.ui.components.JBList" binding="myJBList">
-                <constraints border-constraint="Center"/>
-                <properties/>
-              </component>
-              <grid id="b7ec4" binding="toolbarPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
-                <constraints border-constraint="North"/>
-                <properties/>
-                <border type="none"/>
-                <children/>
-              </grid>
-            </children>
-          </grid>
-          <grid id="b566c" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-            <margin top="0" left="0" bottom="0" right="0"/>
+          <grid id="ca9b3" binding="splitterPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
             <constraints border-constraint="Center"/>
             <properties/>
-            <border type="none"/>
+            <border type="empty">
+              <size top="0" left="5" bottom="0" right="0"/>
+            </border>
             <children>
-              <component id="4f3af" class="com.intellij.ui.EditorTextField" binding="myEditorTextField" custom-create="true">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-                </constraints>
+              <grid id="3e5b" layout-manager="BorderLayout" hgap="0" vgap="0">
+                <constraints border-constraint="West"/>
                 <properties/>
-              </component>
+                <border type="none"/>
+                <children>
+                  <component id="c0121" class="com.intellij.ui.components.JBList" binding="myJBList">
+                    <constraints border-constraint="Center"/>
+                    <properties>
+                      <model/>
+                    </properties>
+                  </component>
+                  <grid id="b7ec4" binding="toolbarPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
+                    <constraints border-constraint="North"/>
+                    <properties/>
+                    <border type="none"/>
+                    <children/>
+                  </grid>
+                </children>
+              </grid>
+              <grid id="b566c" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints border-constraint="Center"/>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="4f3af" class="com.intellij.ui.EditorTextField" binding="myEditorTextField" custom-create="true">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
+                </children>
+              </grid>
             </children>
           </grid>
         </children>

--- a/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateAllSetterSettingForm.form
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateAllSetterSettingForm.form
@@ -24,7 +24,7 @@
               <grid id="fb8f2" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
                 <border type="none"/>

--- a/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateSetterState.java
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/template/GenerateSetterState.java
@@ -25,9 +25,18 @@ import java.util.List;
  * @author bruce ge 2022/8/25
  */
 public class GenerateSetterState {
+    private Boolean useJdkClassesOnly = false;
     private Boolean generateByTemplate = false;
 
     private List<Template> templateList = Lists.newArrayList();
+
+    public Boolean getUseJdkClassesOnly() {
+        return useJdkClassesOnly;
+    }
+
+    public void setUseJdkClassesOnly(Boolean useJdkClassesOnly) {
+        this.useJdkClassesOnly = useJdkClassesOnly;
+    }
 
     public Boolean getGenerateByTemplate() {
         return generateByTemplate;
@@ -53,11 +62,19 @@ public class GenerateSetterState {
 
         GenerateSetterState that = (GenerateSetterState) o;
 
-        return new EqualsBuilder().append(generateByTemplate, that.generateByTemplate).append(templateList, that.templateList).isEquals();
+        return new EqualsBuilder()
+                .append(useJdkClassesOnly, that.useJdkClassesOnly)
+                .append(generateByTemplate, that.generateByTemplate)
+                .append(templateList, that.templateList)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(generateByTemplate).append(templateList).toHashCode();
+        return new HashCodeBuilder(17, 37)
+                .append(useJdkClassesOnly)
+                .append(generateByTemplate)
+                .append(templateList)
+                .toHashCode();
     }
 }

--- a/src/main/java/com/bruce/intellijplugin/generatesetter/utils/PsiToolUtils.java
+++ b/src/main/java/com/bruce/intellijplugin/generatesetter/utils/PsiToolUtils.java
@@ -16,6 +16,7 @@ package com.bruce.intellijplugin.generatesetter.utils;
 
 import com.bruce.intellijplugin.generatesetter.Parameters;
 import com.bruce.intellijplugin.generatesetter.RealParam;
+import com.bruce.intellijplugin.generatesetter.template.GenerateSetterService;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
@@ -38,6 +39,11 @@ import java.util.*;
 public class PsiToolUtils {
 
     public static boolean checkGuavaExist(Project project, @NotNull PsiElement element) {
+        GenerateSetterService instance = GenerateSetterService.getInstance();
+        if (instance.getState() != null && Boolean.TRUE.equals(instance.getState().getUseJdkClassesOnly())) {
+            return false;
+        }
+
         Module moduleForPsiElement = ModuleUtilCore.findModuleForPsiElement(element);
         if(moduleForPsiElement==null){
             return false;


### PR DESCRIPTION
option to disable guava code generation - plugin detects it in the project, but some modules do not use guava.

<img width="1012" alt="Screenshot 2023-07-30 at 16 44 48" src="https://github.com/gejun123456/intellij-generateAllSetMethod/assets/644816/201761eb-28ae-429c-a369-ec0697f6743c">

also added splitter in templates settings.